### PR TITLE
on css custom properties, prevent unit to be removed when the value is zero

### DIFF
--- a/plain-css.js
+++ b/plain-css.js
@@ -87,7 +87,12 @@ module.exports = {
     "function-whitespace-after": "always",
     "indentation": 2,
     "keyframe-declaration-no-important": true,
-    "length-zero-no-unit": true,
+    "length-zero-no-unit": [
+      true,
+      {
+        "ignore": ["custom-properties"],
+      }
+    ],
     "max-empty-lines": 1,
     "max-nesting-depth": 3,
     "media-feature-colon-space-after": "always",


### PR DESCRIPTION
othervise stylelint will change

```css
--offset: 0px;
left: calc(var(--offset) + 50%);
```

to `--offset: 0;`. and `left: calc(0 + 50%)` would be invalid.